### PR TITLE
Added ifsbench-based testing setup to ecLand.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,3 +23,5 @@ foreach( test ${tests} )
             INPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/${test}/input
     )
 endforeach()
+
+add_subdirectory( ifsbench )

--- a/tests/ifsbench/CMakeLists.txt
+++ b/tests/ifsbench/CMakeLists.txt
@@ -1,0 +1,49 @@
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+# Detect only the system installed Python3 interpreter.
+set( Python3_FIND_VIRTUALENV STANDARD )
+
+ecbuild_find_package( Python3 COMPONENTS Interpreter REQUIRED VERSION 3.8 )
+
+set( VENV_NAME "ifsbench_venv" )
+set( VENV_PATH "${CMAKE_CURRENT_BINARY_DIR}/${VENV_NAME}" )
+
+# Create a Python virtual environment in the current binary directory.
+ecbuild_info( "Create ifsbench virtual environment ${VENV_NAME}" )
+
+execute_process( COMMAND ${Python3_EXECUTABLE} -m venv ${VENV_PATH} )
+
+set( IFSBENCH_PYTHON "${VENV_PATH}/bin/python3")
+
+# Install the missing Python packages.
+execute_process(
+    COMMAND ${IFSBENCH_PYTHON} -m pip install "ifsbench @ git+https://github.com/ecmwf-ifs/ifsbench.git"
+)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/ifsbench_run.py
+    ${CMAKE_CURRENT_BINARY_DIR}/ifsbench_run.py
+)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/test.yaml
+    ${CMAKE_CURRENT_BINARY_DIR}/test.yaml
+)
+
+foreach(TEST_NAME v1_EU_default v1_EU_centered v1_EU_forward
+    v1_EU_multiprocess v1_EU_multithread v1_EU_multiprocess_thread)
+    ecbuild_add_test(
+        TARGET ecland_ifsbench_${TEST_NAME}
+        TYPE SCRIPT
+        COMMAND ${IFSBENCH_PYTHON}
+        ARGS ${CMAKE_CURRENT_BINARY_DIR}/ifsbench_run.py from_yaml
+            ${CMAKE_CURRENT_BINARY_DIR}/test.yaml ${TEST_NAME}
+            --run-dir=${CMAKE_CURRENT_BINARY_DIR}/ecland_ifsbench_${TEST_NAME}
+    )
+endforeach()

--- a/tests/ifsbench/README.md
+++ b/tests/ifsbench/README.md
@@ -1,0 +1,87 @@
+# ifsbench-based tests
+
+ifsbench (https://github.com/ecmwf-ifs/ifsbench) is a framework for benchmarking/testing that is used in ecLand to easily setup tests.
+It is used in ecLand to easily setup new tests. A test in ecLand is composed of two components: the scientific setup (`science`) and the technical setup (`tech`).
+
+The scientific setup describes what is tested, this includes:
+* Which input files (forcing, soil, surfclim) are used
+* which default namelist is used
+* which modifications are applied to the namelist
+* the default parallel setup
+
+The technical setup doesn't alter the experiment setup but adds some additional technical details, for example
+* additional debug namelist entries
+* additional accelerator information for GPU runs
+* custom environment flags for certain scenarios.
+
+The same scientific setup can for example be used with different technical setups:
+```
+# Runs the my_science scientific setup with the default technical setup.
+ifsbench-run.py from_yaml test.yaml my_science --tech=default
+
+# Runs the my_science scientific setup with the debug technical setup which
+# doesn't change the behaviour of the test but sets additional debug namelist
+# entries.
+ifsbench-run.py from_yaml test.yaml my_science --tech=debug
+
+# Do the same but with an environment variable.
+export IFSBENCH_TECH=debug
+ifsbench-run.py from_yaml test.yaml my_science
+```
+
+Besides the scientific and technical setup, an architecture (`arch`) is needed to run a test. The architecture describes the underlying system and provides the default parallel run launcher (srun, mpirun, ...) and additional information about the hardware setup.
+
+# Running the tests
+
+There are two different ways to run the tests: By calling the ifsbench run script directly or via CTest.
+
+## ifsbench_run.py
+
+Building `ecLand` using CMake will install the `ifsbench_run.py` script in `build_dir/tests/ifsbench` as well as the accompanying YAML test configuration file. The YAML file specifies the available architectures, scientific and technical setups. To run the test, look up the name of the scientific setup that you want to run in the YAML file and run
+```
+ifsbench_run.py <path_to_yaml> <science_setup>
+```
+Several options can be added to alter the run
+* `--run-dir <run_dir>` Specify a directory where the tests will run and which won't be cleaned up after running the test.
+* `--tech <tech_name>` Use the given technical setup when running the tests. Available setups and their names can be looked up in the YAML file.
+* `--arch <arch_name>` Use the given architecture when running the tests. Available architectures and their names can be looked up in the YAML file.
+* `--validate <ref_path>` Check the results against for bit-identicality compared to some reference results stored in the specified file.
+
+Instead of passing these flags, it is also possible to set  the corresponding`IFSBENCH_<FLAG_NAME>` environment variable:
+```
+export IFSBENCH_ARCH=atos
+export IFSBENCH_TECH=debug
+
+ifsbench_run.py <path_to_yaml> <science_setup>
+```
+
+## CTest
+
+Tests that should be available via CTest must be added in the `CMakeLists.txt` file using `ecbuild_add_test`. After building, these tests can then be run by calling `ctest` as usual. To specify flags (like the architecture!) for all tests, you can use the environment-variable approach as shown above
+```
+export IFSBENCH_ARCH=atos
+
+ctest -j 10
+```
+
+# Technical setup
+
+## Runner script
+
+The `ifsbench_run.py` script contains the logic of the ecLand tests:
+* it describes the data pipeline
+* it describes the environment variable setup
+* it describes what an ecLand result is and how it should be validated
+* it provides the `from_yaml` command that actually launches a test/benchmark.
+
+The actual parameters for the tests (which input files, parallel setup, etc.) are specified in a YAML file (usually `yaml.test`) which can easily be expanded to add more tests or to modify existing ones.
+
+## YAML configuration file
+
+The `ifsbench_run.py` script defines an `EclandConfig` class that describes a 1-to-1 correspondence between the YAML file and the resulting Python object. So everything that is specified in the YAML, must also exist in `EclandConfig` (or one of its attributes). The mapping is automatically done by `pydantic`.
+
+# Adding new tests
+
+To add new tests, you have to add a new scientific setup (or technical setup or architecture) to the YAML configuration file. Please edit the YAML file in the `tests/ifsbench` *source* directory, not in the *build* directory (as this will be overwritten when CMake runs).
+The parameters that you have to provide are specified in the `EclandScience` class in `ifsbench_run.py`. The most important ones should be documented in the YAML file itself. Just create a new entry in the `science` section of the YAML file, choose the right input data files and (optionally) add some namelist modifications.
+Once you have adapted the YAML file, you should most likely also add it to CTest (see CTest section above).

--- a/tests/ifsbench/ifsbench_run.py
+++ b/tests/ifsbench/ifsbench_run.py
@@ -1,0 +1,377 @@
+#! @IFSBENCH_PYTHON@
+
+# (C) Copyright 2024- ECMWF.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+from contextlib import nullcontext
+from pathlib import Path
+import re
+from tempfile import TemporaryDirectory
+from typing import List, Dict
+
+import click
+import yaml
+
+from ifsbench import (
+    Benchmark,
+    cli,
+    debug,
+    DataFileStats,
+    DefaultApplication,
+    DefaultArch,
+    EnvHandler,
+    error,
+    Job,
+    PydanticConfigMixin,
+    PydanticDataFrame,
+    ScienceSetup,
+    TechSetup
+)
+
+from ifsbench.data import FetchHandler, NamelistHandler, NamelistOverride, RenameHandler, RenameMode
+from ifsbench.validation import FrameCloseValidation
+
+class EclandResult(PydanticConfigMixin):
+    """
+    Ecland result class that can be serialised using the PydanticConfigMixin approach.
+    """
+
+    #: Numerical results of the run, stored as DataFrames (with corresponding
+    #: file name).
+    frames: Dict[str, PydanticDataFrame]
+
+    #: Standard out of the run.
+    stdout: str = None
+
+    #: Standard error of the run.
+    stderr: str = None
+
+    #: Walltime of the run in seconds.
+    walltime: float = None
+
+    @classmethod
+    def from_rundir(cls, run_dir: Path, **kwargs):
+        """
+        Build a result object from data in a run directory.
+
+        Params
+        ------
+        run_dir: pathlib.Path
+            The run directory.
+        kwargs:
+            If values are given for any of the EclandResult attributes, these
+            values are used instead of the extracted data from the run directory.
+        """
+
+        # Copy the kwargs dict so we can modify it.
+        kwargs = dict(kwargs)
+
+        if 'stderr' in kwargs:
+            # Extract the walltime from the stderr, if necessary.
+            match = re.search(r'wall-time\s*:\s*([0-9\.]+)s', kwargs['stderr'])
+            if match and 'walltime' not in kwargs:
+                kwargs['walltime'] = float(match.group(1))
+
+        # Gather the numerical data by parsing the netCDF files.
+        frames = {}
+
+        # ecLand writes output netCDF files of the form o_<some_name>.nc. Glob
+        # all of them and parse them.
+        paths = sorted(list(run_dir.glob('o_*.nc')))
+
+        for path in paths:
+            stats = DataFileStats(
+                input_path=path,
+                stat_dims=['lat', 'lon'],
+                stat_names=['min', 'max', 'mean']
+            )
+
+            results = stats.get_stats()
+            for result in results:
+                dtypes = getattr(result.index, 'dtypes', [])
+                levels = []
+                for i, dtype in enumerate(dtypes):
+                    if str(dtype).startswith('datetime'):
+                        levels.append(result.index.levels[i].astype(str))
+                    else:
+                        levels.append(result.index.levels[i])
+
+                if hasattr(result.index, 'set_levels'):
+                    result.index = result.index.set_levels(levels)
+
+            if len(results) == 1:
+                frames[path.name] = results[0]
+            else:
+                for i, result in enumerate(results):
+                    frames[f"{path.name}_{i+1}"] = result
+
+
+        if 'frames' not in kwargs:
+            kwargs['frames'] = frames
+
+        return cls(**kwargs)
+
+class EclandScience(PydanticConfigMixin):
+    """
+    Science setup of the ecland benchmark.
+    """
+
+    #: URL to the forcing file.
+    forcing_url: str
+
+    #: URL to the soil file.
+    soil_url: str
+
+    #: URL to the surfclim file.
+    surfclim_url: str
+
+    #: Path to the default namelist.
+    namelist_url: str
+
+    #: Path to the ecland binary.
+    binary_path: Path
+
+    #: List of namelist overrides.
+    namelists: List[NamelistOverride] = None
+
+    #: List of custom environment overrides.
+    env: List[EnvHandler] = None
+
+    #: The default job setup.
+    job: Job = None
+
+class EclandTech(PydanticConfigMixin):
+    """
+    Tech setup of the ecland benchmark.
+    """
+
+    #: List of namelist overrides.
+    namelists: List[NamelistOverride] = None
+
+    #: List of custom environment overrides.
+    env: List[EnvHandler] = None
+
+    #: The number of GPUs that are used per task.
+    gpus_per_task: int = None
+
+
+class EclandConfig(PydanticConfigMixin):
+    """
+    This object describes the format of the YAML/JSON file from which the
+    data is read.
+    """
+    science: Dict[str, EclandScience]
+    tech: Dict[str, EclandTech]
+    arch: Dict[str, DefaultArch]
+
+def build_ecland_benchmark(science: EclandScience, tech: EclandTech) -> Benchmark:
+    """
+    Build an ifsbench Benchmark object from the ecland science and tech
+    objects.
+    """
+
+    # Initial step is to
+    #  * download the binary input files (forcing, soil + surfclim).
+    #  * Fetch the default namelist.
+    data_handlers_init = [
+        FetchHandler(source_url=science.forcing_url, target_path='forcing'),
+        FetchHandler(source_url=science.soil_url, target_path='soilinit'),
+        FetchHandler(source_url=science.surfclim_url, target_path='surfclim'),
+        FetchHandler(source_url=science.namelist_url, target_path='namelist_template')
+    ]
+
+    # At runtime, copy the original namelist back to `input`.
+    data_handlers_runtime = [
+        RenameHandler(pattern='namelist_template', repl='input', mode=RenameMode.COPY)
+    ]
+
+    # If namelist overrides are specified, also run them at runtime.
+    if science.namelists:
+        data_handlers_runtime.append(NamelistHandler(
+            input_path='namelist_template',
+            output_path='input',
+            overrides=science.namelists
+        ))
+
+    env_handlers = []
+
+    if science.env:
+        env_handlers += science.env
+
+    application = DefaultApplication(
+        command = [str(science.binary_path)],
+    )
+
+    science_setup = ScienceSetup(
+        data_handlers_init = data_handlers_init,
+        data_handlers_runtime = data_handlers_runtime,
+        env_handlers = env_handlers,
+        application = application
+    )
+
+
+    data_handlers_runtime = []
+
+    if tech.namelists:
+        data_handlers_runtime.append(NamelistHandler(
+            input_path='namelist_template',
+            output_path='input',
+            overrides=tech.namelists
+        ))
+
+    env_handlers = []
+
+    if tech.env:
+        env_handlers += science.env
+
+    tech_setup = TechSetup(
+        data_handlers_runtime = data_handlers_runtime,
+        env_handlers = env_handlers
+    )
+
+    return Benchmark(science = science_setup, tech=tech_setup)
+
+
+@cli.command('from_yaml', context_settings={"auto_envvar_prefix": "IFSBENCH"})
+@click .argument('yaml-path', type=click.Path(exists=True))
+@click.argument('science', type=str)
+@click.option('--binary-path', type=click.Path(exists=True),
+              help='Path to the ecLand binary')
+@click.option('--tech', type=str, default='default',
+              help='Specify the used technical setup')
+@click.option('--run-dir', type=click.Path(), default=None,
+              help='Run directory for the tests (temporary directory by default)')
+@click.option('--tasks', type=int, default=None,
+              help='Number of tasks to run')
+@click.option('--threads', type=int, default=None,
+              help='Number of threads to use')
+@click.option('--arch', default=None, type=str,
+              help='The architecture to use.')
+@click.option('--launcher-flags', default=[], multiple=True, type=str,
+              help='Additional flags that are passed to the launcher')
+@click.option('--validate', 'validate_path', type=click.Path(exists=True),
+              help='Validate results against given result file.')
+def from_yaml(yaml_path, science, tech, binary_path, run_dir, tasks, threads,
+    arch, launcher_flags, validate_path):
+    """
+    Run ecland benchmark using a YAML configuration file.
+
+    Params
+    ------
+    yaml-path:
+        The path to the configuration YAML file.
+    science:
+        Which science (=experiment) to run. Must exist in the `science` entry
+        of the YAML file.
+    """
+    yaml_path = Path(yaml_path).resolve()
+
+    with yaml_path.open('r', encoding='utf-8') as f:
+        yaml_data = yaml.safe_load(f)
+
+    # Load the full configuration from the YAML file.
+    ecland_config = EclandConfig.from_config(yaml_data)
+
+    # Select the scientific and technical setup.
+    science_input = ecland_config.science[science]
+    tech_input = ecland_config.tech[tech]
+
+    if binary_path:
+        science_input.binary_path = Path(binary_path).resolve()
+
+    benchmark = build_ecland_benchmark(science=science_input, tech=tech_input)
+
+    job = science_input.job
+    if tasks:
+        job.tasks = tasks
+    if threads:
+        job.cpus_per_task = threads
+
+    arch = ecland_config.arch.get(arch, ecland_config.arch['default'])
+
+    if run_dir:
+        run_dir = Path(run_dir).resolve()
+        context = nullcontext(run_dir)
+    else:
+        context = TemporaryDirectory(dir=Path.cwd())
+
+    with context as run_dir:
+        run_dir = Path(run_dir)
+        benchmark.setup_rundir(run_dir)
+
+        bench_result = benchmark.run(
+            run_dir=run_dir,
+            job=job,
+            arch=arch,
+            launcher_flags=launcher_flags
+        )
+
+        result = EclandResult.from_rundir(
+            run_dir=run_dir,
+            stdout=bench_result.stdout,
+            stderr=bench_result.stderr,
+        )
+
+        with (run_dir/'result.yaml').open('w', encoding='utf-8') as f:
+            yaml.dump(result.dump_config(), f)
+
+        if validate_path:
+            validator = FrameCloseValidation(atol=0, rtol=0)
+            with Path(validate_path).open('r', encoding='utf-8') as f:
+                reference = EclandResult.from_config(yaml.safe_load(f))
+
+            if set(result.frames.keys()) != set(reference.frames.keys()):
+                raise RuntimeError("Results do not hold the same frames!")
+
+            for key in result.frames.keys():
+                frame = result.frames[key]
+                frame_ref = reference.frames[key]
+
+                equal, mismatch = validator.compare(frame, frame_ref)
+
+                if not equal and mismatch:
+                    idx, col = mismatch[0]
+                    error(f"First mismatch at ({idx}, {col}): {frame.loc[idx,col]} != {frame_ref.loc[idx,col]}.")
+
+                    for idx, col in mismatch:
+                        debug(f"Mismatch at ({idx}, {col}): {frame.loc[idx,col]} != {frame_ref.loc[idx,col]}.")
+
+
+@cli.command('validate', context_settings={"auto_envvar_prefix": "IFSBENCH"})
+@click.argument('result', type=click.Path(exists=True))
+@click.argument('reference', type=click.Path(exists=True))
+def validate(result, reference):
+    """
+    Compare two ecland result files and check for bit-identicality.
+    """
+    validator = FrameCloseValidation(atol=0, rtol=0)
+
+    with Path(result).open('r', encoding='utf-8') as f:
+        result = EclandResult.from_config(yaml.safe_load(f))
+
+    with Path(reference).open('r', encoding='utf-8') as f:
+        reference = EclandResult.from_config(yaml.safe_load(f))
+
+    if set(result.frames.keys()) != set(reference.frames.keys()):
+        raise RuntimeError("Results do not hold the same frames!")
+
+    for key in result.frames.keys():
+        frame = result.frames[key]
+        frame_ref = reference.frames[key]
+
+        equal, mismatch = validator.compare(frame, frame_ref)
+
+        if not equal and mismatch:
+            idx, col = mismatch[0]
+            error(f"First mismatch at ({idx}, {col}): {frame.loc[idx,col]} != {frame_ref.loc[idx,col]}.")
+
+            for idx, col in mismatch:
+                debug(f"Mismatch at ({idx}, {col}): {frame.loc[idx,col]} != {frame_ref.loc[idx,col]}.")
+
+if __name__ == "__main__":
+    cli(auto_envvar_prefix='IFSBENCH')

--- a/tests/ifsbench/namelist_v1_EU
+++ b/tests/ifsbench/namelist_v1_EU
@@ -1,0 +1,123 @@
+! (C) Copyright 2005- ECMWF.
+!
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
+  &NAMCT01S
+    NSTART=0        ! first timestep of model 0 
+    NSTOP=94   !1488               ! last timestep of model 
+    NFRPOS=94   !1488                ! frequency of post-processing events (time-steps)
+    NFRRES=0                 ! frequency of writing intermediate restart files (time-steps)
+    LNF=.TRUE.               ! .T. = start, .F. = restart
+    NCYCLE=1                ! number of the experiment
+    CNMEXP="DEFAULT"            ! name of the experiment
+    /
+    &NAMDYN1S
+    TSTEP=1800             !  TSTEP   : length of the timestep in seconds
+    NACCTYPE=2              ! =0  Forcing fluxes assument centered on timestamp (linear interp.)
+                            ! =1  forward accumulation (starting at timestamp)
+                            ! =2  backward accumulation (ending at timestamp)
+    LSWINT=.FALSE.          ! SWdown solar angle interpolation if true 
+    LPREINT=.FALSE.         ! precipitation interpolation if true
+    LFLXINT=.FALSE.         ! SWdown/LWdown linear interpolation if true 
+    /
+    &NAMDIM
+    NLAT=101               ! number of latitudes
+    NLON=175               ! number of longitudes
+    NDFORC=48              ! namelist forcing dimension
+    NCSS=4                   ! number of vertical layers in the soil
+    NCSNEC=5                 ! number of vertical layer in the snow 
+    /
+    &NAMRIP
+    NINDAT=20220101       ! run initial date in the form YYYYMMDD 
+    NSSSSS=0       ! initial time in seconds (e.g. for 12h, 43200)
+    /
+    &NAM1S
+    CFFORC='netcdf'          ! CHARACTER: IDENTIFIES THE FORCING DATA SET
+    CFOUT='netcdf'           ! CHARACTER: IDENTIFIES THE OUTPUT DATA SET
+    CFSURF='netcdf'          ! CHARACTER: IDENTIFIES THE SURFACE CLIMATOLOGY DATA SET 
+    CFINIT='netcdf'          ! CHARACTER: IDENTIFIES THE INITIALIZATION DATA SET
+    CMODID='EcLand'         ! CHARACTER: MODEL IDENTIFICATION
+    LACCUMW=.TRUE.           ! LOGICAL : WRITE OUT ACCUMULATED FLUXES (DEFAULT=TRUE)
+    LRESET=.TRUE.            ! LOGICAL : RESET ACCUMULATION EVERY WRITE OUT TIME STEP
+    NACCUR=1               ! INTEGER : OUTPUT CDF ACCURACY: 1=SINGLE PREC, 2=DOUBLE PREC
+    NDIMCDF=2         ! INTEGER : NR OF GRID DIMENSIONS
+    NDLEVEL=0                ! INTEGER : Level of netcdf4 compression 0-9: 0== no compression -faster output
+    NCDFTYPE=4               ! type of netcdf output 
+    LWRGG=.TRUE.            ! logical, wrtie o_gg  - instantaneus prognostics 
+    LWRCLM=.TRUE.            ! logical, write o_fix - fix soil properties 
+    LWRGGD=.FALSE.            ! logical, write o_ggd - mean prognostic evolution
+    LWREFL=.FALSE.            ! logical, write o_efl - surface energy balance 
+    LWRWAT=.FALSE.            ! logical, write o_wat - water balance
+    LWRD2M=.FALSE.            ! logical, write o_d2m - 2 meters diagnostics 
+    LWRSUS=.FALSE.            ! logical, write o_sus - surface state variables (vegT,albedo, etc..)
+    LWREVA=.FALSE.            ! logical, write o_eva - evaporation components 
+    LWRCLD=.FALSE.            ! logical, write o_cld - cold processes variables 
+    LWRCO2=.FALSE.           ! logical, write o_co2 - cO2 fluxes 
+    LWRBIO=.FALSE.           ! logical, write o_bio - biomass 
+    LWRVEG=.FALSE.           ! logical, write o_veg - vegetation 2D high/low veg 
+    LWRVTY=.FALSE.           ! logical, write o_vty - vegetation 2D high/low veg biomass
+    LWRTIL=.FALSE.           ! logical, write o_til - tiles 2D (tile) state
+    LWRLKE=.FALSE.           ! logical, write o_lke - lake variables - not active for now... 
+    LSEMISS=.FALSE.          ! LOGICAL : EMISSIVITY SET TO CONSTANT VALUE REMISS
+    LDBGS1=.FALSE.           ! LOGICAL : PRINT DEBUG INFO, EG FORCING DATA (DEFAULT=FALSE)
+    IDBGS1=1                 ! Debug level : output printing
+    LNCSNC=.FALSE.
+    /
+    &NAMFORC
+    
+    ZPHISTA=10.000         ! REFERENCE LEVEL (FOR T, Q) last model level ERAI
+    ZUV=10.000                ! REFERENCE LEVEL FOR WIND   last model level ERAI
+    ZDTFORC=3600            ! FORCING TIME STEP     
+    INSTFC=0                 ! NUMBER OF TIME STEPS TO BE READ (0 = ALL)
+    NDIMFORC=2        ! NUMBER OF GRID DIMENSIONS in FORCING
+    LOADIAB=.FALSE.          ! FLAG FOR APPLYING ADIABATIC HEIGHT CORRECTION
+    CFORCV="forcing"
+    CFORCU="forcing"
+    CFORCT="forcing"
+    CFORCQ="forcing"
+    CFORCP="forcing"
+    CFORCRAIN="forcing"
+    CFORCSNOW="forcing"
+    CFORCSW="forcing"
+    CFORCLW="forcing"
+    /
+&NAMPHY
+    LEVGEN=.TRUE.                  ! LOGICAL : TURN THE VAN GENUCHTEN HYDROLOGY ON
+    LESSRO=.TRUE.                  ! LOGICAL : TURN THE SUB-GRID SURFACE RUNOFF ON
+    LEFLAKE=.TRUE.                 ! LOGICAL : TURN THE FLAKE ON
+    LESN09=.TRUE.                  ! LOGICAL : TURN THE NEW SNOW PARAMETERIZATION ON
+    LELAIV=.TRUE.                  ! LOGICAL : TURN THE LAI SEASONAL ON
+    LECTESSEL=.TRUE.               ! LOGICAL : TURN CTESSEL ON
+    LEAGS=.FALSE.                  ! LOGICAL : TURN AGS EVAPORATION
+    LEFARQUHAR=.TRUE.              ! LOGICAL : TURN ON FARQUHAR PHOTOSYNTHESIS (true: Farquhar; false: A-gs)
+    LEOPTSURF=.FALSE.              ! LOGICAL : USE FARQUHAR PARAMETERS FROM NAMELIST (OTHERWISE USE DEFAULT VALUES)
+    LEAIRCO2COUP=.FALSE.           ! LOGICAL : TURN ATM CO2 COUPLING WITH PHOTOSYNTHESIS
+    LEC4MAP=.TRUE.                 ! LOGICAL : Use C3/C4 photosynthesis pathway map from climate fields (if false it assigns C3/C4 according to PFT)
+    RLAIINT=0                      ! Coefecient for interactive LAI relaxation with clim
+                                   ! (1 fully interactive; 0 fully clim)
+    LECLIM10D=.F.                  ! LOGICAL : TURN usage of 10-day Climatology for Alb and LAI
+    LEINTWIND=.T.
+    LESNML=.TRUE.
+    LECMF1WAY=.F.    ! Logical : Turn on Coupling with CaMa-Flood
+    LECMF2LAKEC=0    ! Integer: 2way coupling : 0 -> off, 1 -> replace , 2 -> add
+    /
+&NAMOPTSURF
+   /
+&NAMPHYOFF
+    LEWBCHECK=.FALSE.
+    LEWBCHECKAbort=.FALSE.
+    LESNCHECK=.FALSE.
+    LESNCHECKAbort=.FALSE.
+    LEWBSOILFIX=.TRUE.
+    LESKTI5=.FALSE.
+    LESKTI8=.FALSE.
+    LEWARMSTART=.FALSE.
+    LECOLDSTART=.FALSE.
+    LESOILCOND=.TRUE.
+    LESNWBCON=.FALSE.
+    LEROLAKE=.TRUE.
+    /

--- a/tests/ifsbench/test.yaml
+++ b/tests/ifsbench/test.yaml
@@ -1,0 +1,104 @@
+arch:
+  # Specify architecture definitions here.
+
+  # Default architecture. Uses mpirun and no additional hardware information.
+  default:
+    launcher:
+      launcher_type: MpirunLauncher
+    cpu_config: {}
+
+  atos:
+    launcher:
+      launcher_type: SrunLauncher
+    cpu_config:
+      sockets_per_node: 2
+      cores_per_socket: 64
+      threads_per_core: 2
+      gpus_per_node: 0
+
+  # Architecture for runs on the LUMI-C partition. Specifies default account
+  # and partition. Change this if necessary.
+  lumi-c:
+    launcher:
+      launcher_type: SrunLauncher
+    cpu_config:
+      sockets_per_node: 2
+      cores_per_socket: 64
+      threads_per_core: 2
+      gpus_per_node: 0
+    account: project_465000527
+    partition: small
+
+science:
+  # Specify science definitions here.
+
+  v1_EU_default: &v1_EU
+    # Path to the actual ecland executable. 
+    binary_path: @CMAKE_BINARY_DIR@/bin/ecland-master
+
+    # Paths to the three standard input files. These should be given as URLs,
+    # so either as https://something or file:///home/me/something.
+    forcing_url: https://get.ecmwf.int/repository/ecland/tests/v1/2D_EU-001_20220101-20220102/met_2DHT_EU-001_20220101-20220102.nc
+    soil_url: https://get.ecmwf.int/repository/ecland/tests/v1/2D_EU-001_20220101-20220102/surfinit_EU-001_20220101-20220102.nc
+    surfclim_url: https://get.ecmwf.int/repository/ecland/tests/v1/2D_EU-001_20220101-20220102/surfclim_EU-001_20220101-20220102.nc
+
+    # Path to the default namelist.
+    namelist_url: file://@CMAKE_CURRENT_SOURCE_DIR@/namelist_v1_EU
+
+    # Default parallel setup. May be overwritten at runtime by command line flags.
+    job:
+      tasks: 1
+      cpus_per_task: 1
+
+  v1_EU_centered:
+    # Use YAML anchor/alias here to essentially copy the content of v1_EU_default
+    # here and just override the namelists.
+    <<: *v1_EU
+    namelists:
+      # Set additional namelist flags here. `mode` can also be `delete` or
+      # `append`.
+      - mode: set
+        namelist: NAMDYN1S
+        entry: NACCTYPE
+        value: 0
+
+  v1_EU_forward:
+    <<: *v1_EU
+    namelists:
+      - mode: set
+        namelist: NAMDYN1S
+        entry: NACCTYPE
+        value: 1
+
+  v1_EU_multiprocess:
+    <<: *v1_EU
+    job:
+      tasks: 4
+
+  v1_EU_multithread:
+    <<: *v1_EU
+    job:
+      tasks: 1
+      threads: 4
+
+  v1_EU_multiprocess_thread:
+    <<: *v1_EU
+    job:
+      tasks: 4
+      threads: 4
+
+tech:
+  # Specify technical setups here.
+  default: {}
+
+  debug:
+    namelists:
+      - mode: set
+        namelist: NAM1S
+        entry: LDBGS1
+        value: true
+      - mode: set
+        namelist: NAM1S
+        entry: IDBGS1
+        value: 1
+


### PR DESCRIPTION
(Draft pull request as this isn't using a properly tagged ifsbench version)

I've added an ifsbench-based testing framework to ecLand that allows us to easily specify new tests in a yaml file (see `tests/ifsbench/test.yaml`). A detailed how-to (and what-is-this-doing) can be found in the `tests/ifsbench/README.md` file.
Main features:

- Necessary input files are fetched automatically from get.ecmwf.int
- Experiments can easily be modified/created by adding a few lines to a YAML file.
- Results are read from the netCDF files and can easily be checked for bit-identicality if reference data is available.
- Tests are available via CTest but can also be run manually.

What's not here yet:

- Tests are not used in Github Actions.
- Only bit-identicality testing is available at the moment, no ensemble-based/confidence interval-based testing.
- CMake points to the main branch of ifsbench, not to a tagged version. This has to be fixed before merging! To run the tests, you need at the moment the latest `ifsbench/main` with the fixes in https://github.com/ecmwf-ifs/ifsbench/pull/48.