### PR TITLE
Strip eccodes dependency of unnecessary components for faster build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ ecland_run.sh
 tools/create_forcing/scripts/osm_pyutils/cython_ext.c
 tools/create_forcing/scripts/osm_pyutils/cython_ext.cpython-311-x86_64-linux-gnu.so
 
+#test temporaries
+tests/ifsbench/ifsbench_ecland.egg-info

--- a/cmake/ecland_fetchcontent_dependencies.cmake
+++ b/cmake/ecland_fetchcontent_dependencies.cmake
@@ -11,14 +11,17 @@ if (HAVE_FETCHCONTENT_DEPENDENCIES)
 #### eccodes
 FetchContent_Declare(
   eccodes
-  URL https://github.com/ecmwf/eccodes/archive/refs/tags/2.44.0.tar.gz
+  URL https://github.com/ecmwf/eccodes/archive/refs/tags/2.46.0.tar.gz
   FIND_PACKAGE_ARGS
 )
 set( ECCODES_ENABLE_MEMFS ON )
 set( ECCODES_ENABLE_TESTS OFF )
 set( ECCODES_ENABLE_JPG OFF )
 set( ECCODES_ENABLE_PNG OFF )
-
+set( ECCODES_ENABLE_NETCDF OFF )
+set( ECCODES_ENABLE_JPG_LIBJASPER OFF )
+set( ECCODES_ENABLE_JPG_LIBOPENJPEG OFF )
+set( ECCODES_ENABLE_PRODUCT_GRIB OFF )
 
 #### fiat
 FetchContent_Declare(


### PR DESCRIPTION
This PR strips eccodes dependency of unused components. To make sure it will not interfere with the newest eccodes, dependency points now to 2.46