### PR TITLE
Use temporary ssd storage on hpc2020 for CI

### DIFF
--- a/share/ecland/scripts/ecland-launch
+++ b/share/ecland/scripts/ecland-launch
@@ -54,7 +54,10 @@ if command_exists srun ; then
 
   if [[ ${ECPLATFORM:-unset} == "hpc2020" ]]; then
     if [ -z "${SLURM_JOB_QOS}" ]; then
-      ECLAND_LAUNCH_ARGS="${ECLAND_LAUNCH_ARGS} -q np"
+      qos=${ECLAND_LAUNCH_QOS:-np}
+      [[ -n "${ECLAND_CI}" ]] && qos=nf
+      ECLAND_LAUNCH_ARGS="${ECLAND_LAUNCH_ARGS} -q ${qos}"
+      [[ ${qos} == "nf" ]] && ECLAND_LAUNCH_ARGS="${ECLAND_LAUNCH_ARGS} --gres=ssdtmp:40G"
     fi
   fi
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ foreach( test ${tests} )
         ARGS ${TEST_ARGS}
         ENVIRONMENT
             ECLAND_MASTER=${CMAKE_BINARY_DIR}/bin/${PROJECT_NAME}-master
+            ECLAND_CI=1
             WORK_DIR=${CMAKE_CURRENT_BINARY_DIR}/${test}/work
             OUTPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/${test}/output
             INPUT_DIR=${CMAKE_CURRENT_BINARY_DIR}/${test}/input


### PR DESCRIPTION
For gnu compilers, the ecland CI takes over an hour to run on the atos perm. The problem only seems to manifest for gnu on the hpc2020 perm file system; it runs fine in the github ci, locally on the mac and also runs fine on an ecinteractive session. The offending test is the 1D test, which features a lot of small reads/writes to disk.

This PR amends the ecland-launch script to use temporary ssd storage to the run the CI when on the hpc2020 system. If this problem also manifests on other systems and for other compiler toolchains, then a proper fix will be needed.
 