### PR TITLE
Add hpc ci

### DIFF
--- a/.github/tools/install-nvhpc.sh
+++ b/.github/tools/install-nvhpc.sh
@@ -79,13 +79,22 @@ echo "+ ${TEMPORARY_FILES}/${FOLDER}/install"
 #rm -rf "${TEMPORARY_FILES}/${FOLDER}"
 
 NVHPC_VERSION=$(basename "${NVHPC_INSTALL_DIR}"/Linux_$(uname -m)/*.*/)
+NVHPC_DIR=${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}
 
 # Use gcc which is available in PATH
-${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}/compilers/bin/makelocalrc \
-  -x ${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}/compilers/bin \
+${NVHPC_DIR}/compilers/bin/makelocalrc \
+  -x ${NVHPC_DIR}/compilers/bin \
   -gcc $(which gcc) \
   -gpp $(which g++) \
   -g77 $(which gfortran)
+
+# Locate the bundled OpenMPI prefix. From 25.x the comm_libs/mpi symlink points
+# at hpcx (a bin-only directory), so we derive the real prefix from the location
+# of openmpi-default-hostfile and fall back to comm_libs/mpi for older releases.
+MPI_HOME=$(dirname $(dirname $(find ${NVHPC_DIR}/comm_libs -name openmpi-default-hostfile -path '*/etc/*' 2>/dev/null | head -1)))
+if [ -z "${MPI_HOME}" ] || [ ! -d "${MPI_HOME}" ]; then
+    MPI_HOME=${NVHPC_DIR}/comm_libs/mpi
+fi
 
 cat > ${NVHPC_INSTALL_DIR}/env.sh << EOF
 ### Variables
@@ -99,7 +108,7 @@ export NVHPC_LIBRARY_PATH=\${NVHPC_DIR}/compilers/lib
 export LD_LIBRARY_PATH=\${NVHPC_LIBRARY_PATH}
 
 ### MPI
-export MPI_HOME=\${NVHPC_DIR}/comm_libs/mpi
+export MPI_HOME=${MPI_HOME}
 export PATH=\${MPI_HOME}/bin:\${PATH}
 EOF
 

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -1,0 +1,100 @@
+name: build-hpc
+
+on:
+  # Trigger the workflow on all pull requests
+  pull_request: ~
+
+  # Allow workflow to be dispatched on demand
+  workflow_dispatch: ~
+
+  # Trigger after public PR approved for CI
+  pull_request_target:
+    types: [labeled]
+
+env:
+  ECLAND_TOOLS: ${{ github.workspace }}/.github/tools
+  CTEST_PARALLEL_LEVEL: 1
+
+jobs:
+  ci-hpc:
+    name: ci-hpc
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        name:
+          - ac-cpu intel
+          - ac-cpu nvhpc
+
+        include:
+          - name: ac-cpu intel
+            site: ac-batch
+            sbatch_options: |
+              #SBATCH --time=00:20:00
+              #SBATCH --nodes=1
+              #SBATCH --ntasks=4
+              #SBATCH --cpus-per-task=32
+              #SBATCH --hint=nomultithread
+              #SBATCH --mem=60GB
+              #SBATCH --qos=np
+            arch: ecmwf/hpc2020/intel/2023.2.0/hpcx-openmpi/2.9.0
+            build_options: ~
+
+          - name: ac-cpu nvhpc
+            site: ac-batch
+            sbatch_options: |
+              #SBATCH --time=00:20:00
+              #SBATCH --nodes=1
+              #SBATCH --ntasks=4
+              #SBATCH --cpus-per-task=32
+              #SBATCH --hint=nomultithread
+              #SBATCH --mem=60GB
+              #SBATCH --qos=np
+            arch: ecmwf/hpc2020/nvhpc/24.5/hpcx-openmpi/2.17.1
+            build_options: ~
+
+    runs-on: [self-hosted, linux, hpc]
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
+        with:
+          site: ${{ matrix.site }}
+          troika_user: ${{ secrets.HPC_CI_SSH_USER }}
+          sbatch_options: ${{ matrix.sbatch_options }}
+          template: |
+            REPO=${{ github.event.pull_request.head.repo.full_name || github.repository }}
+            SHA=${{ github.event.pull_request.head.sha || github.sha }}
+            { set +x; } 2>/dev/null # trace off
+
+            echo "::group::Checkout $(basename $REPO)"
+            { set -x; } 2>/dev/null # trace on
+            mkdir -p $REPO
+            pushd $REPO
+            git init
+            git remote add origin ${{ github.server_url }}/$REPO
+            git fetch origin $SHA
+            git reset --hard FETCH_HEAD
+            { set +x; } 2>/dev/null # trace off
+            echo "::endgroup::"
+
+            echo "::group::ecland-bundle create"
+            { set -x; } 2>/dev/null # trace on
+            ./ecland-bundle create
+            { set +x; } 2>/dev/null # trace off
+            echo "::endgroup::"
+
+            echo "::group::ecland-bundle build"
+            { set -x; } 2>/dev/null # trace on
+            ./ecland-bundle build --arch arch/${{ matrix.arch }} --ninja --keep-going --retry-verbose ${{ matrix.build_options }}
+            { set +x; } 2>/dev/null # trace off
+            echo "::endgroup::"
+
+            echo "::group::ecLand test"
+            { set -x; } 2>/dev/null # trace on
+            export IFSBENCH_ARCH=atos
+            ctest --test-dir build/ecland -VV --output-on-failure
+            { set +x; } 2>/dev/null # trace off
+            echo "::endgroup::"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,10 +261,9 @@ jobs:
         cache_suffix: "${{ matrix.build_type }}-${{ env.CACHE_SUFFIX }}"
         recreate_cache: ${{ matrix.caching == false }}
         dependencies: |
-          ecmwf/ecbuild
+          ecmwf/ecbuild@develop
           ecmwf-ifs/fiat@refs/tags/1.6.2
           ecmwf/eccodes@refs/tags/2.44.0
-        dependency_branch: develop
         dependency_cmake_options: |
           ecmwf/eccodes: "-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_MEMFS=ON -DENABLE_JPG=OFF -DENABLE_PNG=OFF ${{ matrix.dep_eccodes_extra_options }}"
           ecmwf-ifs/fiat: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_DR_HOOK_NVTX=OFF -DENABLE_MPI=ON"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         prec: ['DP', 'SP'] # Standalone driver not 'SP' compatible yet
         name:
           - linux gnu-14
-          - linux nvhpc-24.5
+          - linux nvhpc-25.9
           - linux intel-classic
           - linux intel-modern
           - macos
@@ -49,13 +49,18 @@ jobs:
             compiler_fc: gfortran-14
             caching: true
 
-          - name: linux nvhpc-24.5
+          - name: linux nvhpc-25.9
             os: ubuntu-24.04
-            compiler: nvhpc-24.5
+            compiler: nvhpc-25.9
             compiler_cc: nvc
             compiler_cxx: nvc++
             compiler_fc: nvfortran
             cmake_options: -DCMAKE_CXX_FLAGS=--diag_suppress177
+            # nvc++ 25.9 has a codegen bug where an AVX-512 SCALEFS node is
+            # emitted by an idiom-recognition pass even on non-AVX-512 targets,
+            # causing llc to ICE on some GH runner CPUs. Pin -tp=haswell to
+            # constrain the target features so the pass cannot emit it.
+            dep_eccodes_extra_options: -DCMAKE_CXX_FLAGS=-tp=haswell
             caching: true
 
           - name : linux intel-classic
@@ -166,7 +171,7 @@ jobs:
       if: contains( matrix.compiler, 'nvhpc' )
       shell: bash -eux {0}
       run: |
-        ${ECLAND_TOOLS}/install-nvhpc.sh --prefix /opt/nvhpc --version 24.5
+        ${ECLAND_TOOLS}/install-nvhpc.sh --prefix /opt/nvhpc --version 25.9
         source /opt/nvhpc/env.sh
         echo "${NVHPC_DIR}/compilers/bin"                   >> $GITHUB_PATH
         [ -z ${MPI_HOME+x} ] || echo "MPI_HOME=${MPI_HOME}" >> $GITHUB_ENV
@@ -261,7 +266,7 @@ jobs:
           ecmwf/eccodes@refs/tags/2.44.0
         dependency_branch: develop
         dependency_cmake_options: |
-          ecmwf/eccodes: "-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_MEMFS=ON -DENABLE_JPG=OFF -DENABLE_PNG=OFF"
+          ecmwf/eccodes: "-DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_MEMFS=ON -DENABLE_JPG=OFF -DENABLE_PNG=OFF ${{ matrix.dep_eccodes_extra_options }}"
           ecmwf-ifs/fiat: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_DR_HOOK_NVTX=OFF -DENABLE_MPI=ON"
         cmake_options: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_options }} -DENABLE_SINGLE_PRECISION=${{ matrix.prec == 'SP' }}"
         self_build: true

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -1,0 +1,10 @@
+# Manage labels of pull requests that originate from forks
+name: label-public-pr
+ 
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+ 
+jobs:
+  label:
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # contents of .gitignore
 
 # specific ignores
-build*
+*build*/
 install
 .vscode
 source/*

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The following options can be configured directly during the bundle build step:
 | `--without-mpi` | Disable MPI |
 | `--without-omp` | Disable OpenMP |
 | `--with-single-precision` | Enable single precision build |
-| `--without-test` | Disable tests |
+| `--without-tests` | Disable tests |
 | `--build-type=<arg>` | `<Debug\|RelWithDebInfo\|Release\|Bit>` |
 | `--install-dir=<install-prefix>` | Install location |
 

--- a/ecland-bundle
+++ b/ecland-bundle
@@ -3,7 +3,7 @@
 # BOOTSTRAP ecbundle-build or ecbundle-create,
 # and pass arguments to it.
 
-ecbundle_VERSION=develop
+ecbundle_VERSION=2.4.0
 
 BUNDLE_DIR="$( cd $( dirname "${BASH_SOURCE[0]}" ) && pwd -P )"
 


### PR DESCRIPTION
This PR contributes an hpc-ci, with nvhpc and intel cpu builds. Importantly, the nvhpc ci builds are removed, as these failed intermittently when building eccodes.
 