### PR TITLE
Exclude unused hdf5 and netcdf c components from build

### DIFF
--- a/.github/tools/install-hdf5.sh
+++ b/.github/tools/install-hdf5.sh
@@ -52,11 +52,26 @@ fi
 if [ "$USE_CONFIGURE_BUILD" = true ]; then
    cd ${TEMPORARY_FILES}/hdf*
    mkdir -p "${HDF5_INSTALL_DIR}"
-   ./configure --prefix="${HDF5_INSTALL_DIR}" --enable-shared --enable-fortran --enable-hl
+   ./configure --prefix="${HDF5_INSTALL_DIR}"  \
+   --enable-shared \
+   --disable-fortran \
+   --disable-tools \
+   --disable-szip-support \
+   --disable-tests \
+   --disable-static \
+   -disable-dependency-tracking
    make -j
    make install
 else
-   cmake -G Ninja -S  ${TEMPORARY_FILES}/${FOLDER} -B "build-${FOLDER}" -DHDF5_BUILD_FORTRAN=ON -DHDF5_BUILD_HL_LIB=ON -DBUILD_TESTING=OFF 
+   cmake -G Ninja -S  ${TEMPORARY_FILES}/${FOLDER} -B "build-${FOLDER}"\
+   -DHDF5_BUILD_FORTRAN=OFF \
+   -DHDF5_BUILD_HL_LIB=ON  \
+   -DHDF5_BUILD_TOOLS=OFF \
+   -DHDF5_BUILD_EXAMPLES=OFF \
+   -DHDF5_ONLY_SHARED_LIBS=ON \
+   -DHDF5_ENABLE_SZIP_SUPPORT=OFF \
+   -DBUILD_TESTING=OFF 
+
    cmake --build  "build-${FOLDER}" --config Release
    cmake --install "build-${FOLDER}" --prefix ${HDF5_INSTALL_DIR}
 fi

--- a/.github/tools/install-netcdf-c.sh
+++ b/.github/tools/install-netcdf-c.sh
@@ -45,6 +45,13 @@ mkdir -p ${TEMPORARY_FILES}/build-${FOLDER} && cd ${TEMPORARY_FILES}/build-${FOL
 rm -rf ./*
 cmake -G Ninja ${TEMPORARY_FILES}/${FOLDER} \
     -DHDF5_DIR=${HDF5_ROOT}/cmake -DCMAKE_INSTALL_PREFIX="${NETCDF_INSTALL_DIR}" \
-    -DENABLE_TESTS=OFF
+    -DENABLE_DAP=OFF \
+    -DENABLE_BYTERANGE=OFF \
+    -DENABLE_NCZARR=OFF \
+    -DBUILD_UTILITIES=OFF \
+    -DENABLE_EXAMPLES=OFF \
+    -DENABLE_TESTS=OFF \
+    -DENABLE_PLUGINS=OFF \
+    -DENABLE_CDF5=OFF 
 cmake --build . --config Release
 cmake --install .


### PR DESCRIPTION
This PR aims at optimization of the CI process. This minor change exclude compilation options of Necdf-C and HDF5 that are ON by default but not needed by the ecland software stack
 