### PR TITLE
fix: CDS levelist retrieval, HPC2020 permissions, and build installation path documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following options can be configured directly during the bundle build step:
 | `--with-single-precision` | Enable single precision build |
 | `--without-tests` | Disable tests |
 | `--build-type=<arg>` | `<Debug\|RelWithDebInfo\|Release\|Bit>` |
-| `--install-dir=<install-prefix>` | Install location |
+| `--install-dir=<install-prefix>` | Install location (Important: to prevent breaking incremental builds, avoid specifying a directory inside your build folder) |
 
 Additional CMake options can be set via:
 
@@ -138,6 +138,8 @@ Once the environment is properly configured, a standalone build can be performed
 3. Install ecland:
 
     cmake --install `<path-to-build>` --parallel `<nthreads>`
+
+*Note: If setting `CMAKE_INSTALL_PREFIX` during configuration, avoid setting it to a directory inside the build folder `<path-to-build>` to prevent breaking incremental builds.*
 
 
 Running ecLand

--- a/tools/create_forcing/README.md
+++ b/tools/create_forcing/README.md
@@ -191,7 +191,7 @@ to the MARS database, you should get a cds api access token first (more informat
         sodir:      ./ecland_input/clim/          # output dir for initial cond and static fields
         fodir:      ./ecland_input/forcing/       # output dir for forcing
         scriptsdir: <full_path_to_create_forcing_dir>/scripts/ # Directory with create_forcing scripts
-        retrieve_with: cds         
+        retrieve_with: cds                        # Other option: mars 
 
 
 The block `initial_conditions` allows to specify some variables to select what type of data to download.
@@ -209,8 +209,9 @@ For users outside of ecmwf, these variables should not be modified as ERA5 data 
         CLIMVERSION: "v015"    # the version of the climate data used for the initial condition data. 
                                # ERA5 uses the v015
         clim_data_loc: "cds" # the location of the climate data used for the initial condition data. 
-                               # external users should set it to "cds"
-                               # emcwf users can set it to internal "ecmwf" path.
+                               # - external users should set it to "cds"
+                               # - emcwf users can set it to internal "ecmwf" path.
+			       # Important: in order to use the "ecmwf" option, the user needs to have access to the IFS UNIX group.
 
 
 The block `forcing` allows to specify some variables to select what type of forcing data to download.

--- a/tools/create_forcing/scripts/osm_pyutils/extract_process_cds.py
+++ b/tools/create_forcing/scripts/osm_pyutils/extract_process_cds.py
@@ -18,20 +18,20 @@ from datetime import timedelta
 
 def download_from_cds(DATE, STREAM, TIME, STEPS_VAR, dataName, type_data, dataFormat, grbVars, grbLevType, grbLev,outFile):
     c = cdsapi.Client()
-    c.retrieve(dataName,
-    {
-    'date'    : DATE,
-    'time'    : TIME,
-    'param'   : grbVars,
-    'levtype' : grbLevType,
-    'levelist': grbLev,
-    'stream'  : STREAM,
-    'step'    : STEPS_VAR,
-    'type'    : type_data,
-    'format'  : dataFormat,
-    },
-    outFile
-)
+    request = {
+        'date'    : DATE,
+        'time'    : TIME,
+        'param'   : grbVars,
+        'levtype' : grbLevType,
+        'stream'  : STREAM,
+        'step'    : STEPS_VAR,
+        'type'    : type_data,
+        'data_format'  : dataFormat,
+    }
+    # Only include levelist if it's not None (surface fields don't have levelist)
+    if grbLev is not None:
+        request['levelist'] = grbLev
+    c.retrieve(dataName, request, outFile)
 
 # Function to deaccumulate flux variables, derive total precipitation and convert units
 def deacc_variable(data, pp, FREQ):


### PR DESCRIPTION
This pull request introduces three targeted improvements to the ecLand utility and documentation:

1. **Fix `levelist` issue during CDS retrievals (`extract_process_cds.py`):**
   Only include the `levelist` keyword in the `cdsapi` retrieve request when vertical levels (`grbLev`) are explicitly defined. This prevents data retrieval failures when extracting surface fields that do not support or require vertical levels.

2. **Document IFS UNIX group access requirement on HPC2020 (`tools/create_forcing/README.md`):**
   Added a clarification note in the configuration section indicating that accessing the internal `"ecmwf"` option for climate data on HPC2020 requires the user to belong to the `ifs` UNIX group.

3. **Warn against setting `CMAKE_INSTALL_PREFIX` inside the build tree (`README.md`):**
   Added documentation cautioning users not to set their installation directory inside their build folder (`<path-to-build>`), as doing so pollutes the build tree, disrupts CMake's dependency tracking, and prevents incremental builds from functioning correctly.
