### PR TITLE
CI: Avoid unsupported UCX transport on GitHub runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,6 +223,16 @@ jobs:
         # Add mpirun to path for testing
         [ -z ${MPI_HOME+x} ] || echo "${MPI_HOME}/bin" >> $GITHUB_PATH
 
+        # Force UCX (and thus OpenMPI's UCX PML) onto TCP + shared-memory transports.
+        # The GitHub-hosted Azure runners intermittently expose a MANA (mana_0) RDMA/
+        # InfiniBand device on which UCX fails to create UD queue-pairs, causing
+        # MPI_Init to abort ("failed to create UD QP ... Operation not supported").
+        # These are single-node tests that never need RDMA, so restrict transports to
+        # loopback TCP + shared memory to make MPI startup deterministic.
+        echo "UCX_TLS=tcp,self,sm" >> $GITHUB_ENV
+        echo "UCX_NET_DEVICES=lo"  >> $GITHUB_ENV
+        echo "UCX_LOG_LEVEL=error" >> $GITHUB_ENV
+
     - name: Install HDF5
       if: contains( matrix.compiler, 'intel' ) || contains(matrix.compiler, 'nvhpc') || contains(matrix.compiler, 'flang')
       run: |


### PR DESCRIPTION
### Description

Fix to the recently failing NVHPC CI runner failures on main. This forces NVHPC's HPC-X Open MPI to use the ob1 PML because UCX cannot reliably initialise the Azure MANA device used by GitHub-hosted runners.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 